### PR TITLE
Install and configure Danger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+rvm: 2.3.1
+
+script:
+  - bundle exec danger

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,1 @@
+commit_lint.check

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,1 +1,14 @@
 commit_lint.check
+
+if status_report.values.flatten.any?
+  markdown <<~DANGER_EXPLANATION
+  At the Ministry of Justice, we use \
+  [Danger](https://github.com/ministryofjustice/danger) to ensure our \
+  commits and pull requests follow [our style \
+  rules](https://github.com/ministryofjustice/danger/blob/master/Dangerfile).
+
+  If you think one of the points here has been raised in error (or \
+  shouldn't be in our style guide), open an issue or pull request on [our \
+  Danger config](https://github.com/ministryofjustice/danger).
+  DANGER_EXPLANATION
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "danger"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "danger"
+gem "danger-commit_lint"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,51 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    claide (1.0.1)
+    claide-plugins (0.9.2)
+      cork
+      nap
+      open4 (~> 1.3)
+    colored2 (3.1.2)
+    cork (0.3.0)
+      colored2 (~> 3.1)
+    danger (5.2.1)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored2 (~> 3.1)
+      cork (~> 0.1)
+      faraday (~> 0.9)
+      faraday-http-cache (~> 1.0)
+      git (~> 1)
+      kramdown (~> 1.5)
+      octokit (~> 4.2)
+      terminal-table (~> 1)
+    faraday (0.12.1)
+      multipart-post (>= 1.2, < 3)
+    faraday-http-cache (1.3.1)
+      faraday (~> 0.8)
+    git (1.3.0)
+    kramdown (1.13.2)
+    multipart-post (2.0.0)
+    nap (1.1.0)
+    octokit (4.7.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    open4 (1.3.4)
+    public_suffix (2.0.5)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    terminal-table (1.7.3)
+      unicode-display_width (~> 1.1.1)
+    unicode-display_width (1.1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  danger
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,8 @@ GEM
       kramdown (~> 1.5)
       octokit (~> 4.2)
       terminal-table (~> 1)
+    danger-commit_lint (0.0.6)
+      danger (~> 5.0)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
@@ -46,6 +48,7 @@ PLATFORMS
 
 DEPENDENCIES
   danger
+  danger-commit_lint
 
 BUNDLED WITH
    1.10.6

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Ministry of Justice
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# Danger
+
+[Danger](http://danger.systems) runs during our CI process, and lets us
+ensure our commits, pull requests, and more meet a minimum level
+of quality.
+
+## Setup
+
+Enable Danger for a project within the [ministryofjustice
+organization](https://github.com/ministryofjustice).
+
+### Configure Danger to use this repo's Dangerfile
+
+Commit a `Dangerfile` containing linking to this repo:
+
+```ruby
+danger.import_dangerfile(github: 'ministryofjustice/danger')
+```
+
+### If you're running Ruby
+
+Add `danger` to your `Gemfile`.
+
+```ruby
+gem 'danger'
+```
+
+#### Run Danger in CI
+
+Add Danger to `.travis.yml`:
+
+```yaml
+before_script:
+  - bundle exec danger
+```
+
+… or add it to your build matrix:
+
+```yaml
+matrix:
+  include:
+    - rvm: 2.3.1
+      script:
+        - bundle exec danger
+```
+
+### If you're not running Ruby
+
+If Danger is your only Ruby dependency, you probably don't want to have
+a Gemfile cluttering up your repo. In that case, you can (probably) use
+this command in the Travis config above:
+
+```bash
+rbenv global 2.3.1 && gem install danger --version '~> 5.0' && danger
+```


### PR DESCRIPTION
We're going to use http://danger.systems/ to automate common code review chores.

This PR installs it, sets it up to ensure commit messages follow [the rules in Tim Pope's blog
post](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), configures Travis to run Danger against this repo, and adds some basic documentation.