### PR TITLE
Fail PRs that contain squashable commits

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,5 +1,9 @@
 commit_lint.check
 
+if git.commits.any? { |c| c.message =~ /^Merge branch/ }
+  fail('Please rebase to get rid of the merge commits in this PR')
+end
+
 if status_report.values.flatten.any?
   markdown <<~DANGER_EXPLANATION
   At the Ministry of Justice, we use \

--- a/Dangerfile
+++ b/Dangerfile
@@ -4,6 +4,10 @@ if git.commits.any? { |c| c.message =~ /^Merge branch/ }
   fail('Please rebase to get rid of the merge commits in this PR')
 end
 
+if git.commits.any? { |c| c.message =~ /^(fixup|squash)!/ }
+  fail('Please rebase to get rid of the fixup and squash commits in this PR')
+end
+
 if status_report.values.flatten.any?
   markdown <<~DANGER_EXPLANATION
   At the Ministry of Justice, we use \


### PR DESCRIPTION
This adds more checks to ensure the commit history is clean, notably:

- Noting merge comments in the PR
- Don't allow merging PRs with commits that should be squashed
- Warn about PR still considered work in progress