### PR TITLE
Ensure pull requests aren't works-in-progress

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,5 +1,9 @@
 commit_lint.check
 
+if github.pr_title.upcase.include? "WIP"
+  warn('This PR is still a work in progress (it has `WIP` in the title).')
+end
+
 if git.commits.any? { |c| c.message =~ /^Merge branch/ }
   fail('Please rebase to get rid of the merge commits in this PR')
 end


### PR DESCRIPTION
This ensures that the pull request doesn't contain `[WIP]` in the title, i.e. it's a work-in-progress.