### PR TITLE
Allow merge commits (temporarily)

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -4,10 +4,6 @@ if github.pr_title.upcase.include? "WIP"
   warn('This PR is still a work in progress (it has `WIP` in the title).')
 end
 
-if git.commits.any? { |c| c.message =~ /^Merge branch/ }
-  fail('Please rebase to get rid of the merge commits in this PR')
-end
-
 if git.commits.any? { |c| c.message =~ /^(fixup|squash)!/ }
   fail('Please rebase to get rid of the fixup and squash commits in this PR')
 end


### PR DESCRIPTION
With this rule in place, anyone using 'squash-and-merge'
would be nagged incessantly about merge commits that github
will automatically remove, anyway. So, disable this rule
until all monitored repos are using the same strategy.

This is a temporary, pragmatic solution, so that I can add
Danger to the tax-tribunals-datacapture repo, and we 
can start to get some real-world usage information.