### PR TITLE
Pin the danger gem to a known good major version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    ministryofjustice-danger (0.1.1)
-      danger
-      danger-commit_lint
+    ministryofjustice-danger (0.1.2)
+      danger (~> 5)
+      danger-commit_lint (~> 0)
 
 GEM
   remote: https://rubygems.org/

--- a/ministryofjustice-danger.gemspec
+++ b/ministryofjustice-danger.gemspec
@@ -2,11 +2,11 @@
 
 Gem::Specification.new do |s|
   s.name = 'ministryofjustice-danger'
-  s.version = '0.1.1'
+  s.version = '0.1.2'
   s.authors = ['Ministry of Justice']
   s.email = ['tools+danger@digital.justice.gov.uk']
   s.license = 'MIT'
-  s.date = '2017-05-12'
+  s.date = '2017-05-18'
 
   s.required_ruby_version = '>= 2.3.0'
 
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['README.md']
   s.rdoc_options = ['--main', 'README.md']
 
-  s.add_runtime_dependency 'danger', '>= 0'
-  s.add_runtime_dependency 'danger-commit_lint', '>= 0'
+  s.add_runtime_dependency 'danger', '~> 5'
+  s.add_runtime_dependency 'danger-commit_lint', '~> 0'
 end


### PR DESCRIPTION
Open-ended dependency versions ('>= 0') prevent the gem from
building. Using '~> 0' caused dependency problems in projects
that try to install this gem. Also, for some reason, installing
this gem would use danger version 3, which is quite old.

This change requires danger version 5, which is the current
release, and has been tested by building this gem, and then
installing it both on a mature ruby project and on a test project
which does nothing but try to install this gem.